### PR TITLE
Add machine ID as part of the hostname in /etc/hosts

### DIFF
--- a/deployment/roles/hub-ubuntu/defaults/main.yml
+++ b/deployment/roles/hub-ubuntu/defaults/main.yml
@@ -2,3 +2,4 @@
 ploy_adhoc_channel: 1
 wwwuser: www-data
 frontend_document_root: /var/www/nuimo_hub
+hostname: "{{ploy_hostname}}-{{ansible_machine_id[:4]}}"

--- a/deployment/roles/hub-ubuntu/tasks/main.yml
+++ b/deployment/roles/hub-ubuntu/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: set hostname
   hostname:
-    name: "{{ploy_hostname}}-{{ansible_machine_id[:4]}}"
+    name: "{{hostname}}"
 
 - name: install runtime dependencies
   apt:
@@ -84,8 +84,8 @@
   lineinfile:
     dest: /etc/hosts
     state: present
-    regexp: '{{ploy_hostname}}$'
-    line: '127.0.0.1  {{ploy_hostname}}.local {{ploy_hostname}}'
+    regexp: '{{hostname}}$'
+    line: '127.0.0.1  {{hostname}}.local {{hostname}}'
   tags: avahi
 
 - include: dhcp.yml


### PR DESCRIPTION
Hostname initially is set correctly but `/etc/hosts` entry is missing the machine ID.