### PR TITLE
Tell HASS to stop installing requirements, do it manually

### DIFF
--- a/deployment/roles/hub-hass/tasks/main.yml
+++ b/deployment/roles/hub-hass/tasks/main.yml
@@ -54,19 +54,11 @@
     mode: "0644"
     content: |
       pip==9.0.1
-      aiohttp==1.2.0
-      async-timeout==1.1.0
-      chardet==2.3.0
-      homeassistant==0.36.1
-      Jinja2==2.9.4
-      MarkupSafe==0.23
-      multidict==2.1.4
-      pytz==2016.10
-      PyYAML==3.12
-      requests==2.13.0
-      typing==3.5.3.0
-      voluptuous==0.9.3
-      yarl==0.8.1
+      homeassistant==0.38.2
+      aiohttp_cors==0.5.0  # requirement of HTTP component
+      phue==0.9  # requirement of Philips Hue component
+      SoCo==0.12  # requirement of Sonos component
+      sqlalchemy==1.1.5  # requirement of Recorder (through History) component
 
 - name: install application
   pip:

--- a/deployment/roles/hub-hass/templates/supervisor.conf
+++ b/deployment/roles/hub-hass/templates/supervisor.conf
@@ -1,9 +1,9 @@
 [program:nuimo_hass]
-command = {{deploy_location}}/venv/bin/hass -c {{data_location}}/
+command = {{deploy_location}}/venv/bin/hass -c {{data_location}}/ --skip-pip
 autostart=true
 autorestart=true
 directory={{ deploy_location }}
-stdout_logfile={{ data_location }}/wsgi.log
+stdout_logfile={{ data_location }}/hass.log
 redirect_stderr=true
 stopsignal=QUIT
 user={{ run_user }}


### PR DESCRIPTION
* Install homeassistant and let it install it's dependencies 
* Disable automatic pip intallation, preinstall Sonos / Philips Hue / HTTP libs

