### PR TITLE
Install DBus with apt together with all it's dependencies

### DIFF
--- a/deployment/roles/hub-ubuntu/tasks/main.yml
+++ b/deployment/roles/hub-ubuntu/tasks/main.yml
@@ -23,6 +23,7 @@
     - wireless-tools
     - supervisor
     - python3-venv
+    - python3-dbus
     - libffi-dev
     - libssl-dev
     - lighttpd


### PR DESCRIPTION
dbus-python is available on PyPi but it's dependencies are not