### PR TITLE
Python 3.6 playbook

### DIFF
--- a/deployment/roles/hub-ubuntu/tasks/main.yml
+++ b/deployment/roles/hub-ubuntu/tasks/main.yml
@@ -18,12 +18,9 @@
     state: installed
   with_items:
     - avahi-daemon
-    - python3
     - wpasupplicant
     - wireless-tools
     - supervisor
-    - python3-venv
-    - python3-dbus
     - libffi-dev
     - libssl-dev
     - lighttpd

--- a/deployment/roles/python3-from-src/defaults/main.yml
+++ b/deployment/roles/python3-from-src/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-python_version: 3.5.3
+python_version: 3.6.0
 src_dest: /usr/src/python
 build_dir: "{{src_dest}}/Python-{{python_version}}"

--- a/deployment/roles/python3-from-src/tasks/main.yml
+++ b/deployment/roles/python3-from-src/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-# A role to install Python 3.5 from sources
+# A role to install Python 3 from sources
 # 
 # It was created mainly because we needed a reliable way to install
-# Python 3.5 on Raspbian Jessie, because if we dist-upgraded that to
+# latest Python 3 on Raspbian Jessie, because if we dist-upgraded that to
 # a version that included Python 3.5 the bluetooth device became unavailable
 
 - name: install build dependencies
@@ -76,11 +76,19 @@
     path: "{{build_dir}}/python"
   register: python_binary
 
+- name: get version of currently installed python3 version
+  command: /usr/local/bin/python --version
+  register: existing_python3_version
+  ignore_errors: True
+
+- name: extract python3 version from dict
+  set_fact:
+    existing_python3_version: "{{ existing_python3_version.stdout|default('') }}"
+
 - name: install sources
   command: make install
   args:
     chdir: "{{build_dir}}"
-    creates: /usr/local/bin/python3.5
   tags: python
   become: true
-  when: python_binary.stat.exists == True
+  when: python_binary.stat.exists == True and "Python {{python_version}}" != "{{existing_python3_version}}"


### PR DESCRIPTION
This would build Python 3.6 instead of 3.5