### PR TITLE
Generate configuration for Home Assistant & Nuimo app

### DIFF
--- a/application/development.ini
+++ b/application/development.ini
@@ -34,6 +34,10 @@ wifi_networks_path = /srv/nuimo_hub/data/wifi_networks.json
 wifi_setup_flag_path = /srv/nuimo_hub/data/WIFI_SETUP_REQUIRED
 nuimo_mac_address_filepath = /srv/nuimo_hub/data/nuimo_mac_address.txt
 devices_path = /srv/nuimo_hub/data/devices.json
+data_path = /srv/nuimo_hub/data
+hass_config_path = /srv/nuimo_hass/data/configuration.yaml
+hass_phue_config_path = /srv/nuimo_hass/data/phue.conf
+nuimo_app_config_path = /srv/nuimo_app/data/nuimo_app.cfg
 bluetooth_adapter_name = hci0
 
 [loggers]

--- a/application/setup.py
+++ b/application/setup.py
@@ -83,5 +83,6 @@ setup(
         enter_wifi_setup = senic.nuimo_hub.commands:enter_wifi_setup
         join_wifi = senic.nuimo_hub.commands:join_wifi
         setup_nuimo = senic.nuimo_hub.commands:setup_nuimo
+        create_configurations = senic.nuimo_hub.commands:create_configuration_files_and_restart_apps
     """,
 )

--- a/deployment/roles/hub-backend/templates/production.ini
+++ b/deployment/roles/hub-backend/templates/production.ini
@@ -17,6 +17,9 @@ wifi_setup_flag_path = {{data_location}}/WIFI_SETUP_REQUIRED
 devices_path = {{data_location}}/devices.json
 nuimo_mac_address_filepath = {{data_location}}/nuimo_mac_address.txt
 bluetooth_adapter_name = hci0
+hass_config_path = /srv/nuimo_hass/data/configuration.yaml
+hass_phue_config_path = /srv/nuimo_hass/data/phue.conf
+nuimo_app_config_path = /srv/nuimo_app/data/nuimo_app.cfg
 
 [loggers]
 keys = root, app


### PR DESCRIPTION
Command-line tool to generate HASS & Nuimo app config to be used as the last step of on-boarding.

No tests required since `command.py` is nicely excluded :P Not sure how much from this will stay in the end so probably no point to bother with tests...