### PR TITLE
Improve nuimo discovery

### DIFF
--- a/application/senic/nuimo_hub/nuimo_setup.py
+++ b/application/senic/nuimo_hub/nuimo_setup.py
@@ -13,6 +13,7 @@ class NuimoSetup(nuimo.ControllerManagerListener, nuimo.ControllerListener):  # 
         self._manager.listener = self
         self._is_running = False  # Prevents from considering D-Bus events if we aren't running
         self._discovery_timeout_timer = None
+        self._connect_timeout_timer = None
         self._controller = None
         self._required_mac_address = None
 

--- a/application/setup.py
+++ b/application/setup.py
@@ -38,7 +38,7 @@ setup(
         'click',
         'colander',
         'cornice<2.0',
-        'nuimo>=0.2.3',
+        'nuimo>=0.3.0,<0.4.0',
         'pyramid',
         'pyramid_tm',
         'pytz',


### PR DESCRIPTION
- Fixes one issue where an instance variable wasn't defined. 
- Now nuimo lib >= 0.3.0 is required, it fixes mainly that D-Bus signal connections weren't removed