### PR TITLE
Fix path to config

### DIFF
--- a/application/senic/nuimo_hub/tests/test_setup_wifi.py
+++ b/application/senic/nuimo_hub/tests/test_setup_wifi.py
@@ -39,7 +39,7 @@ def test_join_wifi(browser, setup_url, mocked_run, settings):
         [
             'sudo',
             '%s/join_wifi' % settings['bin_path'],
-            '-c {config_ini_path}'.format(**settings),
+            '-c', settings['config_ini_path'],
             'grandpausethisnetwork',
             'foobar',
         ]

--- a/application/senic/nuimo_hub/views/setup_wifi.py
+++ b/application/senic/nuimo_hub/views/setup_wifi.py
@@ -44,7 +44,7 @@ def join_network(request):
     run([
         'sudo',
         os.path.join(request.registry.settings['bin_path'], 'join_wifi'),
-        '-c {config_ini_path}'.format(**request.registry.settings),
+        '-c', request.registry.settings['config_ini_path'],
         ssid,
         password,
     ])


### PR DESCRIPTION
There was an extra whitespace added to the path name which abspath()
didn't appreciate