### PR TITLE
Make sure users exist before using them in a role

### DIFF
--- a/deployment/roles/hub-backend/meta/main.yml
+++ b/deployment/roles/hub-backend/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: hub-users }

--- a/deployment/roles/hub-backend/tasks/main.yml
+++ b/deployment/roles/hub-backend/tasks/main.yml
@@ -1,26 +1,4 @@
 ---
-- name: create application group
-  become: true
-  group:
-    name: "{{run_user}}"
-
-- name: create application user
-  become: true
-  user:
-    name: "{{run_user}}"
-    group: "{{run_user}}"
-    createhome: yes
-    shell: /bin/sh
-
-- name: create deploy user
-  become: true
-  user:
-    name: "{{build_user}}"
-    groups: "{{run_user}}"
-    append: yes
-    createhome: yes
-    shell: /bin/sh
-
 - name: create deployment location
   become: true
   file:

--- a/deployment/roles/hub-develop/meta/main.yml
+++ b/deployment/roles/hub-develop/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: hub-users }

--- a/deployment/roles/hub-hass/meta/main.yml
+++ b/deployment/roles/hub-hass/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: hub-users }

--- a/deployment/roles/hub-hass/tasks/main.yml
+++ b/deployment/roles/hub-hass/tasks/main.yml
@@ -1,26 +1,4 @@
 ---
-- name: create application group
-  become: true
-  group:
-    name: "{{run_user}}"
-
-- name: create application user
-  become: true
-  user:
-    name: "{{run_user}}"
-    group: "{{run_user}}"
-    createhome: yes
-    shell: /bin/sh
-
-- name: create deploy user
-  become: true
-  user:
-    name: "{{build_user}}"
-    groups: "{{run_user}}"
-    append: yes
-    createhome: yes
-    shell: /bin/sh
-
 - name: create deployment location
   become: true
   file:

--- a/deployment/roles/hub-nuimo-app/meta/main.yml
+++ b/deployment/roles/hub-nuimo-app/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: hub-users }

--- a/deployment/roles/hub-ubuntu/meta/main.yml
+++ b/deployment/roles/hub-ubuntu/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: hub-users }

--- a/deployment/roles/hub-users/tasks/main.yml
+++ b/deployment/roles/hub-users/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: create application group
+  become: true
+  group:
+    name: "{{run_user}}"
+
+- name: create application user
+  become: true
+  user:
+    name: "{{run_user}}"
+    group: "{{run_user}}"
+    createhome: yes
+    shell: /bin/sh
+
+- name: create deploy user
+  become: true
+  user:
+    name: "{{build_user}}"
+    groups: "{{run_user}}"
+    append: yes
+    createhome: yes
+    shell: /bin/sh

--- a/deployment/roles/python3-from-src/meta/main.yml
+++ b/deployment/roles/python3-from-src/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: hub-users }

--- a/deployment/roles/ubuntu-bluez/meta/main.yml
+++ b/deployment/roles/ubuntu-bluez/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: hub-users }


### PR DESCRIPTION
Running any of the roles for the first time would end with an error unless you had run `hub-backend` role first. 

I created a new role that creates users/groups & made it a dependency for any role that's using any of them (actually all of them)