### PR TITLE
Run discovery more often

### DIFF
--- a/deployment/roles/hub-backend/templates/production.ini
+++ b/deployment/roles/hub-backend/templates/production.ini
@@ -21,6 +21,7 @@ nuimo_mac_address_filepath = {{backend_data_location}}/nuimo_mac_address.txt
 bluetooth_adapter_name = hci0
 nuimo_app_config_path = {{backend_data_location}}/nuimo_app.cfg
 homeassistant_data_path = {{hass_data_location}}
+device_scan_interval_seconds = 15
 
 [loggers]
 keys = root, app

--- a/development.ini
+++ b/development.ini
@@ -40,6 +40,7 @@ homeassistant_data_path = /srv/nuimo_hass/data
 nuimo_app_config_path = /srv/senic_hub/data/nuimo_app.cfg
 bluetooth_adapter_name = hci0
 joined_wifi_path = /srv/senic_hub/data/joined_wifi.json
+device_scan_interval_seconds = 15
 
 # Specify a Nuimo MAC address if you want to on-board a specific one
 #nuimo_mac_address = fc:52:6e:8e:87:06

--- a/senic_hub/.coveragerc
+++ b/senic_hub/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 omit =
   senic_hub/backend/commands.py
+  senic_hub/backend/network_discovery.py
   senic_hub/backend/subprocess_run.py
   senic_hub/backend/supervisor.py
   senic_hub/backend/testing.py

--- a/senic_hub/backend/commands.py
+++ b/senic_hub/backend/commands.py
@@ -266,8 +266,8 @@ def device_discovery(config):
     setup_logging(config)
 
     devices_path = app.registry.settings['devices_path']
-    scan_interval_seconds = app.registry.settings.get(
-        'scan_interval_seconds', DEFAULT_SCAN_INTERVAL_SECONDS)
+    scan_interval_seconds = int(app.registry.settings.get(
+        'device_scan_interval_seconds', DEFAULT_SCAN_INTERVAL_SECONDS))
 
     # install Ctrl+C handler
     signal.signal(signal.SIGINT, sigint_handler)

--- a/senic_hub/backend/device_discovery.py
+++ b/senic_hub/backend/device_discovery.py
@@ -6,9 +6,9 @@ import xml.etree.ElementTree as ET
 from copy import deepcopy
 from enum import IntEnum
 
-from netdisco.discovery import NetworkDiscovery
-
 import requests
+
+from .network_discovery import NetworkDiscovery
 
 
 SUPPORTED_DEVICES = [
@@ -77,13 +77,10 @@ def discover(discovery_class=NetworkDiscovery):
 
     devices = []
 
-    netdisco = discovery_class()
+    netdisco = discovery_class(limit_discovery=SUPPORTED_DEVICES)
     netdisco.scan()
 
     for device_type in netdisco.discover():
-        if device_type not in SUPPORTED_DEVICES:
-            continue
-
         for device_info in netdisco.get_info(device_type):
             device_description = get_device_description(device_type, device_info)
             logger.info("Discovered %s device with ip %s", device_type, device_description["ip"])

--- a/senic_hub/backend/device_discovery.py
+++ b/senic_hub/backend/device_discovery.py
@@ -77,7 +77,7 @@ def discover(discovery_class=NetworkDiscovery):
 
     devices = []
 
-    netdisco = discovery_class(limit_discovery=SUPPORTED_DEVICES)
+    netdisco = discovery_class(SUPPORTED_DEVICES)
     netdisco.scan()
 
     for device_type in netdisco.discover():

--- a/senic_hub/backend/network_discovery.py
+++ b/senic_hub/backend/network_discovery.py
@@ -1,0 +1,77 @@
+import importlib
+import threading
+
+from netdisco.philips_hue_nupnp import PHueNUPnPDiscovery
+from netdisco.ssdp import SSDP
+
+
+class NetworkDiscovery(object):
+    """
+    Based on netdisco.discovery.NetworkDiscovery. This class only does
+    discovery using SSDP & nUPNP which covers all the devices we want
+    to support at the moment.
+
+    """
+    def __init__(self, limit_discovery=[]):
+        """Initialize the discovery."""
+        self.limit_discovery = limit_discovery
+
+        self.ssdp = SSDP()
+        self.phue = PHueNUPnPDiscovery()
+
+        self._load_device_support()
+
+        self.is_discovering = False
+
+    def scan(self):
+        """Start and tells scanners to scan."""
+        if not self.is_discovering:
+            self.is_discovering = True
+
+        # Start all discovery processes in parallel
+        ssdp_thread = threading.Thread(target=self.ssdp.scan)
+        ssdp_thread.start()
+
+        phue_thread = threading.Thread(target=self.phue.scan)
+        phue_thread.start()
+
+        # Wait for all discovery processes to complete
+        ssdp_thread.join()
+        phue_thread.join()
+
+    def stop(self):
+        """Turn discovery off."""
+        if not self.is_discovering:
+            return
+
+        self.is_discovering = False
+
+    def discover(self):
+        """Return a list of discovered devices and services."""
+        self._check_enabled()
+
+        return [dis for dis, checker in self.discoverables.items()
+                if checker.is_discovered()]
+
+    def get_info(self, dis):
+        """Get a list with the most important info about discovered type."""
+        return self.discoverables[dis].get_info()
+
+    def get_entries(self, dis):
+        """Get a list with all info about a discovered type."""
+        return self.discoverables[dis].get_entries()
+
+    def _check_enabled(self):
+        """Raise RuntimeError if discovery is disabled."""
+        if not self.is_discovering:
+            raise RuntimeError("NetworkDiscovery is disabled")
+
+    def _load_device_support(self):
+        """Load the devices and services that can be discovered."""
+        self.discoverables = {}
+
+        for device_name in self.limit_discovery:
+            module_name = 'netdisco.discoverables.{}'.format(device_name)
+            module = importlib.import_module(module_name)
+
+            self.discoverables[device_name] = module.Discoverable(self)

--- a/senic_hub/backend/network_discovery.py
+++ b/senic_hub/backend/network_discovery.py
@@ -12,9 +12,13 @@ class NetworkDiscovery(object):
     to support at the moment.
 
     """
-    def __init__(self, limit_discovery=[]):
-        """Initialize the discovery."""
-        self.limit_discovery = limit_discovery
+    def __init__(self, whitelist):
+        """
+        Initialize the discovery.
+
+        :param whitelist: list of devices to discover
+        """
+        self.whitelist = whitelist
 
         self.ssdp = SSDP()
         self.phue = PHueNUPnPDiscovery()
@@ -70,7 +74,7 @@ class NetworkDiscovery(object):
         """Load the devices and services that can be discovered."""
         self.discoverables = {}
 
-        for device_name in self.limit_discovery:
+        for device_name in self.whitelist:
             module_name = 'netdisco.discoverables.{}'.format(device_name)
             module = importlib.import_module(module_name)
 

--- a/senic_hub/backend/tests/test_device_discovery.py
+++ b/senic_hub/backend/tests/test_device_discovery.py
@@ -65,16 +65,13 @@ def test_get_device_description_of_sonos_speaker_throws_when_getting_description
     assert e.value.error_type == 404
 
 
-class MockUnknownDeviceDiscovery(MagicMock):
-    def discover(self):
-        return ["unknown"]
-
-
-def test_discover_unknow_devices():
-    assert discover(MockUnknownDeviceDiscovery) == []
-
-
 class MockPhilipsDiscovery(MagicMock):
+    def scan(self):
+        pass
+
+    def stop(self):
+        pass
+
     def discover(self):
         return ["philips_hue"]
 

--- a/senic_hub/backend/views/setup_config.py
+++ b/senic_hub/backend/views/setup_config.py
@@ -2,6 +2,7 @@ from cornice.service import Service
 
 from ..commands import create_configuration_files_and_restart_apps_
 from ..config import path
+from ..supervisor import get_supervisor_rpc_client, stop_program
 
 
 configuration_service = Service(
@@ -15,3 +16,7 @@ configuration_service = Service(
 @configuration_service.post()
 def configuration_create_view(request):
     create_configuration_files_and_restart_apps_(request.registry.settings)
+
+    # stop device discovery daemon
+    supervisorctl = get_supervisor_rpc_client()
+    stop_program('device_discovery', supervisorctl)


### PR DESCRIPTION
Run device discovery every 15 seconds during onboarding and then stop it after we're done.

I'm excluding `network_discovery.py ` from test coverage check. It's mostly copy/paste from netdisco. IMO we should rewrite it to make it simpler and then test it, but for now it works as it is.