### PR TITLE
Try reconnecting to Nuimo even when connection fails

### DIFF
--- a/senic_hub/nuimo_app/__init__.py
+++ b/senic_hub/nuimo_app/__init__.py
@@ -5,7 +5,7 @@ from pprint import pformat
 
 from nuimo import (Controller, ControllerListener, ControllerManager, Gesture)
 
-from . import errors, icons
+from . import icons
 
 from .hass import HomeAssistant
 from .led import LEDMatrixConfig
@@ -27,7 +27,7 @@ class NuimoControllerListener(ControllerListener):
     def connect_failed(self, error):
         mac = self.controller.mac_address
         logger.critical("Connection failed %s: %s", mac, error)
-        raise errors.NuimoControllerConnectionError
+        self.controller.connect()
 
     def disconnect_succeeded(self):
         mac = self.controller.mac_address

--- a/senic_hub/nuimo_app/__main__.py
+++ b/senic_hub/nuimo_app/__main__.py
@@ -2,7 +2,7 @@ import configparser
 import logging
 import sys
 
-from . import NuimoApp, components, errors
+from . import NuimoApp, components
 
 
 # TODO: Read from main ini file
@@ -42,7 +42,7 @@ def main(config_file_path=DEFAULT_CONFIG_FILE_PATH):
 
     try:
         nuimo_app.run()
-    except (KeyboardInterrupt, errors.NuimoControllerConnectionError):
+    except KeyboardInterrupt:
         logger.debug("Stopping...")
         nuimo_app.stop()
 

--- a/senic_hub/nuimo_app/errors.py
+++ b/senic_hub/nuimo_app/errors.py
@@ -1,2 +1,0 @@
-class NuimoControllerConnectionError(Exception):
-    pass


### PR DESCRIPTION
Raising an exception / `sys.exit` wouldn't break out of the main loop, but that's fine for our use case