### PR TITLE
Control more than one Philips Hue light

### DIFF
--- a/senic_hub/backend/tests/data/devices.json
+++ b/senic_hub/backend/tests/data/devices.json
@@ -1,1 +1,18 @@
-[{"id": "ph1", "type": "philips_hue", "ip": "127.0.0.1", "authenticationRequired": true, "authenticated": false}, {"id": "s1", "type": "sonos", "ip": "127.0.0.1", "authenticationRequired": false, "authenticated": true}]
+[
+  {
+    "id": "ph1",
+    "type": "philips_hue",
+    "ip": "127.0.0.1",
+    "authenticationRequired": true,
+    "authenticated": false,
+    "extra": {}
+  },
+  {
+    "id": "s1",
+    "type": "sonos",
+    "ip": "127.0.0.1",
+    "authenticationRequired": false,
+    "authenticated": true,
+    "extra": {}
+  }
+]

--- a/senic_hub/backend/tests/test_setup_devices.py
+++ b/senic_hub/backend/tests/test_setup_devices.py
@@ -40,8 +40,22 @@ def test_device_list_is_empty_if_devices_file_doesnt_exist(no_device_file, brows
 
 def test_device_list_contains_devices(browser, url):
     assert browser.get_json(url).json == [
-        {"id": "ph1", "type": "philips_hue", "ip": "127.0.0.1", "authenticationRequired": True, "authenticated": False},
-        {"id": "s1", "type": "sonos", "ip": "127.0.0.1", "authenticationRequired": False, "authenticated": True},
+        {
+            "id": "ph1",
+            "type": "philips_hue",
+            "ip": "127.0.0.1",
+            "authenticationRequired": True,
+            "authenticated": False,
+            "extra": {},
+        },
+        {
+            "id": "s1",
+            "type": "sonos",
+            "ip": "127.0.0.1",
+            "authenticationRequired": False,
+            "authenticated": True,
+            "extra": {},
+        },
     ]
 
 
@@ -86,6 +100,7 @@ def test_devices_authenticate_view_returns_success(no_phue_config_file, browser,
     payload = [{"success": {"username": "23"}}]
     responses.add(responses.POST, 'http://127.0.0.1/api', json=payload, status=200)
     responses.add(responses.GET, 'http://127.0.0.1/api/23', json={"a": 1}, status=200)
+    responses.add(responses.GET, 'http://127.0.0.1/api/23/lights', json={"1": {}}, status=200)
     responses.add(responses.GET, 'http://127.0.0.1/description.xml', body=philips_hue_bridge_description, status=200)
     assert browser.post_json(auth_url, {}).json == {"id": "ph1", "authenticated": True}
 
@@ -94,6 +109,7 @@ def test_devices_authenticate_view_returns_success(no_phue_config_file, browser,
 def test_devices_authenticate_view_returns_already_authenticated(
         phue_config_file, browser, auth_url, philips_hue_bridge_description):
     responses.add(responses.GET, 'http://127.0.0.1/api/23', json={"a": 1}, status=200)
+    responses.add(responses.GET, 'http://127.0.0.1/api/23/lights', json={"1": {}}, status=200)
     responses.add(responses.GET, 'http://127.0.0.1/description.xml', body=philips_hue_bridge_description, status=200)
     assert browser.post_json(auth_url, {}).json == {"id": "ph1", "authenticated": True}
 

--- a/senic_hub/backend/views/setup_devices.py
+++ b/senic_hub/backend/views/setup_devices.py
@@ -102,7 +102,7 @@ def devices_authenticate_view(request):
     with open(phue_bridge_config, "w") as f:
         json.dump(config, f)
 
-    update_device(device, request.registry.settings)
+    update_device(device, request.registry.settings, username)
 
     return {"id": device_id, "authenticated": authenticated}
 
@@ -152,10 +152,17 @@ def get_device(device_list_path, device_id):
     return device
 
 
-def update_device(device, settings):
+def update_device(device, settings, username):
     devices_path = settings["devices_path"]
     with open(devices_path, "r") as f:
         devices = json.loads(f.read())
+
+    device["extra"]["username"] = username
+
+    if device['authenticated'] and username:
+        bridge = PhilipsHueBridgeApiClient(device["ip"], username)
+
+        device['extra']['lights'] = bridge.get_lights()
 
     device_index = [i for (i, d) in enumerate(devices) if d["id"] == device["id"]].pop()
 

--- a/senic_hub/nuimo_app/components/__init__.py
+++ b/senic_hub/nuimo_app/components/__init__.py
@@ -3,18 +3,15 @@ from threading import Thread
 from .. import matrices
 
 
-class EncoderRing:
-    NUM_POINTS = 1800
+NUIMO_ENCODER_RING_POINTS = 1800
 
-    def __init__(self, min_value, max_value):
-        self.min_value = min_value
-        self.max_value = max_value
 
-    def points_to_value(self, points):
-        return points / self.NUM_POINTS * self.max_value
+def clamp_value(value, range_):
+    return min(max(value, range_.start), range_.stop)
 
-    def clamp_value(self, value):
-        return min(max(value, self.min_value), self.max_value)
+
+def normalize_delta(points, max_value):
+    return points / NUIMO_ENCODER_RING_POINTS * max_value
 
 
 class BaseComponent:

--- a/senic_hub/nuimo_app/components/philips_hue.py
+++ b/senic_hub/nuimo_app/components/philips_hue.py
@@ -1,188 +1,350 @@
 import logging
 
+from pprint import pformat
 from random import random, seed
 from time import sleep, time
 
-from phue import Bridge, PhueRequestTimeout
+from phue import Bridge
 
-from . import BaseComponent, EncoderRing
+from . import BaseComponent, clamp_value, normalize_delta
 
 from .. import matrices
 
 
 COLOR_WHITE_XY = (0.32, 0.336)
-SENIC_HUB_GROUP_NAME = "Senic hub demo"
 
 
 logger = logging.getLogger(__name__)
 
 
+class HueBase:
+    @property
+    def sync_interval(self):
+        """
+        How often to sync with the bridge to detect changes made by
+        external apps.
+        """
+        return 5  # seconds
+
+    def parse_responses(self, responses, request_attributes):
+        errors = [x['error'] for x in responses[0] if 'error' in x]
+        if errors:
+            return {'errors': errors}
+
+        response = self.merge_success_responses(responses)
+        logger.debug("response: %s", response)
+
+        self.update_state_from_response(response)
+        return response
+
+    def merge_success_responses(self, responses):
+        updates = [x['success'] for x in responses[0] if not list(x['success'])[0].endswith('transitiontime')]
+        return {k.rsplit("/", 1)[-1]: v for u in updates for k, v in u.items()}
+
+    def update_state_from_response(self, response):
+        for key, value in response.items():
+            if key == 'bri':
+                self.brightness = value
+
+            elif key == 'on':
+                self.on = value
+
+            elif key == 'bri_inc':
+                # response to bri_inc applied to a group doesn't return actual brightness for some reason...
+                self.brightness = clamp_value(self.brightness + value, range(0, 254))
+
+
+class EmptyLightSet(HueBase):
+    """
+    Wrapper used when we don't have any reachable lights to control
+    """
+
+    def __init__(self):
+        self._on = False
+        self._brightness = 0
+
+    @property
+    def on(self):
+        return self._on
+
+    @property
+    def brightness(self):
+        return self._brightness
+
+    @property
+    def update_interval(self):
+        return 1
+
+    def update_state(self):
+        pass
+
+    def set_attributes(self, attributes):
+        return {'errors': "No reachable lights"}
+
+    @property
+    def sync_interval(self):
+        """
+        How often to sync with the bridge to detect changes made by
+        external apps.
+        """
+        return 60  # seconds
+
+
+class LightSet(HueBase):
+    """
+    Wraps one or multiple lights
+    """
+
+    TRANSITION_TIME = 1  # * 100 milliseconds
+
+    def __init__(self, bridge, light_ids):
+        self.bridge = bridge
+        self.light_ids = light_ids
+
+        self._on = None
+        self._brightness = None
+        self._state = None
+
+    @property
+    def on(self):
+        return self._on
+
+    @on.setter
+    def on(self, other):
+        self._on = other
+
+    @property
+    def brightness(self):
+        return self._brightness
+
+    @brightness.setter
+    def brightness(self, other):
+        self._brightness = other
+
+    @property
+    def update_interval(self):
+        return 0.1
+
+    def update_state(self):
+        """
+        Get current state of all the lights from the bridge
+        """
+        response = self.bridge.get_light()
+        self._state = {k: v['state'] for k, v in response.items() if k in self.light_ids}
+
+        logger.debug("state: %s", pformat(self._state))
+
+        self._on = all(s['on'] for s in self._state.values())
+        self._brightness = min(s['bri'] for s in self._state.values())
+
+        logger.debug("on: %s brightness: %s", self._on, self._brightness)
+
+    def set_attributes(self, attributes):
+        for light_id in self.light_ids:
+            responses = self.bridge.set_light(int(light_id), attributes, transitiontime=self.TRANSITION_TIME)
+            response = self.parse_responses(responses, attributes)
+            if 'errors' in response:
+                # exit early if a call fails
+                return response
+
+        return response
+
+
+class Group(HueBase):
+    """
+    Wraps a Philips Hue group
+    """
+
+    GROUP_NAME = "Senic hub"
+    TRANSITION_TIME = 4  # * 100 ms
+
+    def __init__(self, bridge, light_ids):
+        self.bridge = bridge
+        self.light_ids = light_ids
+
+        self.group_id = self.get_or_create_group()
+
+        self._on = None
+        self._brightness = None
+        self._state = None
+
+    def get_or_create_group(self):
+        groups = self.bridge.get_group()
+        group_id = next((k for k, v in groups.items() if v['name'] == self.GROUP_NAME), None)
+        if not group_id:
+            return self.create_group()
+
+        group_light_ids = set(groups[group_id]['lights'])
+        if group_light_ids != set(self.light_ids):
+            return self.update_group(int(group_id))
+
+        return int(group_id)
+
+    def create_group(self):
+        responses = self.bridge.create_group(self.GROUP_NAME, self.light_ids)
+        logger.debug("create_group responses: %s", responses)
+        response = responses[0]
+        if 'error' in response:
+            logger.error("Error while creating the group: %s", response['error'])
+            return None
+        return int(response['success']['id'])
+
+    def update_group(self, group_id):
+        responses = self.bridge.set_group(group_id, 'lights', self.light_ids)
+        logger.debug("update_group responses: %s", responses)
+        response = responses[0][0]
+        if 'error' in response:
+            logger.error("Error while updating the group: %s", response['error'])
+            return None
+
+        return group_id
+
+    @property
+    def update_interval(self):
+        return 1  # second
+
+    @property
+    def on(self):
+        return self._on
+
+    @on.setter
+    def on(self, other):
+        self._on = other
+
+    @property
+    def brightness(self):
+        return self._brightness
+
+    @brightness.setter
+    def brightness(self, other):
+        self._brightness = other
+
+    def update_state(self):
+        """
+        Get current state of the group from the bridge
+        """
+        state = self.bridge.get_group(self.group_id)
+
+        logger.debug("state: %s", pformat(state))
+
+        self._on = state['state']['all_on']
+        self._brightness = state['action']['bri']
+
+        self._state = state
+
+    def set_attributes(self, attributes):
+        responses = self.bridge.set_group(self.group_id, attributes, transitiontime=self.TRANSITION_TIME)
+        return self.parse_responses(responses, attributes)
+
+
 class Component(BaseComponent):
     MATRIX = matrices.LIGHT_BULB
-
-    # don't send updates to the bridge more often than UPDATE_INTARVAL
-    UPDATE_INTERVAL = 0.1  # seconds
-
-    # how often to sync with the bridge to detect changes made by external apps
-    SYNC_INTERVAL = 5  # seconds
 
     def __init__(self, config):
         super().__init__(config)
 
-        self.encoder = EncoderRing(1, 254)
-
         self.bridge = Bridge(config['ip_address'], config['username'])
-        self.entity_id = self.get_or_create_entity()
 
-        self.is_on = None
-        self.brightness = None
+        self.delta_range = range(-254, 254)
         self.delta = 0
-        self.update_state()
+
+        self.lights = self.create_lights(config['lights'])
+        self.lights.update_state()
 
         # seed random nr generator (used to get random color value)
         seed()
 
-    def get_or_create_entity(self):
-        """
-        Create or update group if there is more than 1 hue bulb
-        available, otherwise return ID of the bulb.
-        """
-        # TODO handle cases when light becomes available later at some point
-        lights = {k: v for k, v in self.bridge.get_light().items() if v['state']['reachable']}
-        if not lights:
-            return None
-        elif len(lights) == 1:
-            return int(list(lights.keys())[0])
+    def create_lights(self, light_ids):
+        lights = [i.strip() for i in light_ids.split(',')]
 
-        groups = self.bridge.get_group()
-        group_id = next((k for k, v in groups.items() if v['name'] == SENIC_HUB_GROUP_NAME), None)
-        if not group_id:
-            return self.create_light_group(lights)
+        reachable_lights = self.filter_reachable(lights)
+        if not reachable_lights:
+            lights = EmptyLightSet()
+        elif len(reachable_lights) > 10:
+            lights = Group(self.bridge, reachable_lights)
+        else:
+            lights = LightSet(self.bridge, reachable_lights)
 
-        group_lights = set(groups[group_id]['lights'])
-        all_lights = set(lights.keys())
+        return lights
 
-        group_id = int(group_id)
-
-        if group_lights != all_lights:
-            return self.update_light_group(group_id, lights)
-
-        return group_id
-
-    def create_light_group(self, lights):
-        response = self.bridge.create_group(SENIC_HUB_GROUP_NAME, list(lights.keys()))
-        return int(response[0]['success']['id'])
-
-    def update_light_group(self, group_id, lights):
-        self.bridge.set_group(group_id, 'lights', list(lights.keys()))
-        return group_id
-
-    def update_state(self):
-        if not self.entity_id:
-            return
-
-        try:
-            settings = self.bridge.get_light(self.entity_id)
-
-            self.is_on = settings['state']['on']
-            self.brightness = settings['state']['bri']
-        except (PhueRequestTimeout, ConnectionResetError):
-            logger.exception()
+    def filter_reachable(self, light_ids):
+        lights = self.bridge.get_light()
+        reachable = [i for i in light_ids if i in lights and lights[i]['state']['reachable']]
+        logger.debug("lights: %s reachable: %s", list(lights.keys()), reachable)
+        return reachable
 
     def on_button_press(self):
-        on = not self.is_on
-        if on and self.brightness:
-            self.set_light_attributes(on=on, bri=self.brightness)
+        on = not self.lights.on
+        if on and self.lights.brightness:
+            self.set_light_attributes(on=on, bri=self.lights.brightness)
         else:
             self.set_light_attributes(on=on)
 
     def set_light_attributes(self, **attributes):
-        if self.entity_id:
-            responses = self.bridge.set_light(self.entity_id, attributes, transitiontime=1)
-            self.set_state_from_responses(responses, attributes)
-        else:
-            self.nuimo.display_matrix(matrices.ERROR)
+        response = self.lights.set_attributes(attributes)
 
-    def set_state_from_responses(self, responses, request_attributes):
-        error = any(x for x in responses[0] if 'error' in x)
-
-        if error:
+        if 'errors' in response:
+            logger.error("Failed to set light attributes: %s", response['errors'])
             self.nuimo.display_matrix(matrices.ERROR)
             return
 
-        updates = self.merge_updates(responses)
-
-        for key, value in updates.items():
-            if key == 'bri':
-                self.brightness = value
-
-                if not self.brightness:
-                    self.turn_off()
-                    return
-
-            elif key == 'on':
-                self.is_on = value
-
-        if 'xy' in updates:
-            if 'bri' in request_attributes:
+        if 'xy' in attributes:
+            if 'bri' in attributes:
                 self.nuimo.display_matrix(matrices.LETTER_W)
             else:
                 self.nuimo.display_matrix(matrices.SHUFFLE)
 
-        elif 'bri' in updates:
-            matrix = matrices.light_bar(self.encoder.max_value, self.brightness)
-            self.nuimo.display_matrix(matrix, fading=True, ignore_duplicates=True)
-
-        elif 'on' in updates:
-            if self.is_on:
-                matrix = matrices.LIGHT_ON
+        elif 'on' in attributes and not ('bri_inc' in attributes):
+            if self.lights.on:
+                self.nuimo.display_matrix(matrices.LIGHT_ON)
             else:
-                matrix = matrices.LIGHT_OFF
+                self.nuimo.display_matrix(matrices.LIGHT_OFF)
 
-            self.nuimo.display_matrix(matrix)
-
-    def merge_updates(self, responses):
-        updates = [x['success'] for x in responses[0] if not list(x['success'])[0].endswith('transitiontime')]
-        return {k.rsplit("/", 1)[-1]: v for u in updates for k, v in u.items()}
+        elif 'bri' in attributes or 'bri_inc' in attributes:
+            if self.lights.brightness:
+                matrix = matrices.light_bar(self.delta_range.stop, self.lights.brightness)
+                self.nuimo.display_matrix(matrix, fading=True, ignore_duplicates=True)
+            else:
+                self.turn_off()
 
     def turn_off(self):
         self.set_light_attributes(on=False)
 
     def on_swipe_left(self):
-        # TODO don't set xy for bulbs that don't support color
-        self.set_light_attributes(on=True, bri=self.brightness, xy=COLOR_WHITE_XY)
+        self.set_light_attributes(on=True, bri=self.lights.brightness, xy=COLOR_WHITE_XY)
 
     def on_swipe_right(self):
-        # TODO don't set xy for bulbs that don't support color
         self.set_light_attributes(on=True, xy=(random(), random()))
 
     def on_rotation(self, value):
         self.delta += value
 
     def run(self):
-        prev_sync_time = 0
+        prev_sync_time = time()
+        prev_update_time = time()
         self.stopping = False
 
         while not self.stopping:
             now = time()
 
-            if self.delta and now - prev_sync_time >= self.UPDATE_INTERVAL:
+            if self.delta and now - prev_update_time >= self.lights.update_interval:
                 self.send_updates()
                 self.delta = 0
 
-                prev_sync_time = now
+                prev_update_time = now
 
-            if now - prev_sync_time >= self.SYNC_INTERVAL:
-                self.update_state()
+            if now - max([prev_sync_time, prev_update_time]) >= self.lights.sync_interval:
+                self.lights.update_state()
 
                 prev_sync_time = now
 
             sleep(0.05)
 
     def send_updates(self):
-        delta = round(self.encoder.points_to_value(self.delta))
+        normalized_delta = normalize_delta(self.delta, self.delta_range.stop)
+        delta = round(clamp_value(normalized_delta, self.delta_range))
 
-        if self.is_on:
+        if self.lights.on:
             self.set_light_attributes(bri_inc=delta)
         else:
             if delta > 0:


### PR DESCRIPTION
1) During on-boarding all the available lights from an authenticated bridge would be added to the device configuration file and the propagated to the Nuimo app config.

2) On startup, Nuimo app would either create a group of lights (if # of lights > 10) and control that or otherwise control each light separately.

Also adding the Philips Hue bridge username to the device configuration file for convenience.